### PR TITLE
Use the new LS-PR status for PR previews

### DIFF
--- a/.pr-preview.json.template
+++ b/.pr-preview.json.template
@@ -3,13 +3,7 @@
     "type": "bikeshed",
     "params": {
         "force": 1,
-        "md-status": "LS-COMMIT",
-        "md-h1": "@@h1@@ <small>(<a href=\"{{ pull_request.html_url }}\">PR #{{ pull_request.number }}</a>)</small>",
-        "md-warning": "Commit {{ short_sha }} {{ pull_request.head.repo.html_url }}/commit/{{ sha }} replaced by {{ config.ls_url }}",
-        "md-title": "{{ config.title }} (Pull Request Snapshot #{{ pull_request.number }})",
-        "md-Text-Macro": "SNAPSHOT-LINK {{ config.back_to_ls_link }}"
-    },
-    "ls_url": "https://@@shortname@@.spec.whatwg.org/",
-    "title": "@@h1@@ Standard",
-    "back_to_ls_link": "<a href=\"https://@@shortname@@.spec.whatwg.org/\" id=\"commit-snapshot-link\">Go to the living standard</a>"
+        "md-status": "LS-PR",
+        "md-Text-Macro": "PR-NUMBER {{ pull_request.number }}"
+    }
 }


### PR DESCRIPTION
Follows https://github.com/tabatkins/bikeshed/pull/1635.