### PR TITLE
Makefile and indentation fixes

### DIFF
--- a/.editorconfig.template
+++ b/.editorconfig.template
@@ -4,7 +4,7 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
-indent_size = 1
+indent_size = 2
 indent_style = space
 trim_trailing_whitespace = true
 max_line_length = 100
@@ -12,5 +12,8 @@ max_line_length = 100
 [Makefile]
 indent_style = tab
 
-[.travis.yml]
-indent_size = 2
+[*.bs]
+indent_size = 1
+
+[*.py]
+indent_size = 4

--- a/.pr-preview.json.template
+++ b/.pr-preview.json.template
@@ -1,9 +1,9 @@
 {
-    "src_file": "@@bs@@.bs",
-    "type": "bikeshed",
-    "params": {
-        "force": 1,
-        "md-status": "LS-PR",
-        "md-Text-Macro": "PR-NUMBER {{ pull_request.number }}"
-    }
+  "src_file": "@@bs@@.bs",
+  "type": "bikeshed",
+  "params": {
+    "force": 1,
+    "md-status": "LS-PR",
+    "md-Text-Macro": "PR-NUMBER {{ pull_request.number }}"
+  }
 }

--- a/Makefile.template
+++ b/Makefile.template
@@ -2,10 +2,10 @@ SHELL=/bin/bash -o pipefail
 .PHONY: local remote deploy review
 
 remote: @@bs@@.bs
-	curl https://api.csswg.org/bikeshed/ -f -F file=@@@bs@@.bs > @@bs@@.html -F md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
+	curl https://api.csswg.org/bikeshed/ -f -F file=@@@bs@@.bs > @@bs@@.html -F md-Text-Macro="COMMIT-SHA LOCAL COPY"
 
 local: @@bs@@.bs
-	bikeshed spec @@bs@@.bs @@bs@@.html --md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
+	bikeshed spec @@bs@@.bs @@bs@@.html --md-Text-Macro="COMMIT-SHA LOCAL COPY"
 
 deploy: @@bs@@.bs
 	curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh@@extra_files@@@@post_build_step@@

--- a/Makefile.template
+++ b/Makefile.template
@@ -2,7 +2,18 @@ SHELL=/bin/bash -o pipefail
 .PHONY: local remote deploy review
 
 remote: @@bs@@.bs
-	curl https://api.csswg.org/bikeshed/ -f -F file=@@@bs@@.bs > @@bs@@.html -F md-Text-Macro="COMMIT-SHA LOCAL COPY"
+	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	                       --output @@bs@@.html \
+	                       --write-out "%{http_code}" \
+	                       --header "Accept: text/plain, text/html" \
+	                       -F die-on=warning \
+	                       -F md-Text-Macro="COMMIT-SHA LOCAL COPY" \
+	                       -F file=@@@bs@@.bs) && \
+	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
+		echo ""; cat @@bs@@.html; echo ""; \
+		rm -f @@bs@@.html; \
+		exit 22 \
+	);
 
 local: @@bs@@.bs
 	bikeshed spec @@bs@@.bs @@bs@@.html --md-Text-Macro="COMMIT-SHA LOCAL COPY"


### PR DESCRIPTION
I'm not sure about the default 2-space indents (vs. e.g. 4-space). The Python files in Encoding use 4-space, notably.