### PR TITLE
Get db.json from sg's master branch

### DIFF
--- a/factory.py
+++ b/factory.py
@@ -79,7 +79,7 @@ def update(templates, variables):
 
 def main():
     templates = gather_templates()
-    db = json.loads(requests.get("https://github.com/whatwg/sg/raw/annevk/db/db.json").text)
+    db = json.loads(requests.get("https://github.com/whatwg/sg/raw/master/db.json").text)
     local_db = json.loads(read_file("factory.json"))
     for workstream in db["workstreams"]:
         for standard in workstream["standards"]:


### PR DESCRIPTION
This change fetches the `db.json` file that acts as the source of truth for the WHATWG repos from the master branch of [whatwg/sg](https://github.com/whatwg/sg), now that whatwg/sg#111 has been merged.