### PR TITLE
Exclude .editorconfig for console

### DIFF
--- a/factory.json
+++ b/factory.json
@@ -4,7 +4,8 @@
   },
   "console": {
     "extra_files": "images/*.*",
-    ".gitignore": ["/.idea", "/node_modules/", "/npm-debug.log"]
+    ".gitignore": ["/.idea", "/node_modules/", "/npm-debug.log"],
+    "not_these_templates": [".editorconfig"]
   },
   "encoding": {
     "extra_files": "*.txt *.json *.css",


### PR DESCRIPTION
Its index.bs is indented 2 spaces, so this .editorconfig should be
synced manually until someone wants to change that.