### PR TITLE
Push branch to origin before invoking `gh pr create`

### DIFF
--- a/factory.py
+++ b/factory.py
@@ -84,8 +84,10 @@ def update(templates, variables):
 
     subprocess.run(["git", "add", "-A"], capture_output=True)
     if b"Changes to be committed" in subprocess.run(["git", "status"], capture_output=True).stdout:
-        subprocess.run(["git", "checkout", "-b", "meta-template/{}".format(uuid.uuid1())], capture_output=True)
+        branch = "meta-template/{}".format(uuid.uuid1())
+        subprocess.run(["git", "checkout", "-b", branch], capture_output=True)
         subprocess.run(["git", "commit", "-m", "Meta: update repository files\n\nSee https://github.com/whatwg/spec-factory for details."], capture_output=True)
+        subprocess.run(["git", "push", "-u", "origin", branch], capture_output=True)
         subprocess.run(["gh", "pr", "create", "-f"])
     os.chdir(".")
 


### PR DESCRIPTION
This is the workaround recommended by the GitHub CLI maintainer:
https://github.com/whatwg/spec-factory/issues/19#issuecomment-651173812

Fixes https://github.com/whatwg/spec-factory/issues/19.
