### PR TITLE
Remove the mention of the Streams standard in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 This repository enables repositories of WHATWG standards to be organized centrally to a certain extent. This is useful for the support files (the files with the `.template` extension), which are often nearly identical and prone to errors.
 
 `factory.py` takes care of updating existing WHATWG standard repositories. It assumes they are in parallel directories using their "shortname" as directory name. `factory.json` supplies data for a exceptional cases.
-
-The Streams Standard is currently not handled.


### PR DESCRIPTION
The Streams standard was indeed handled in PR #15.