### PR TITLE
[webidl] Fix `indent_size` in `.editorconfig` for Bikeshed files

### DIFF
--- a/.editorconfig.template
+++ b/.editorconfig.template
@@ -13,7 +13,7 @@ max_line_length = 100
 indent_style = tab
 
 [*.bs]
-indent_size = 1
+indent_size = @@bikeshed_indent_size@@
 
 [*.py]
 indent_size = 4

--- a/factory.json
+++ b/factory.json
@@ -46,6 +46,7 @@
   },
   "webidl": {
     ".gitignore": ["/node_modules/"],
+    "bikeshed_indent_size": 4,
     "build_with_node": true,
     "post_build_step": "node ./check-grammar.js \"$$DIR/index.html\" && npm run webidl-grammar-post-processor -- --input \"$$DIR/index.html\"",
     "extra_implementers": ["Deno", "Node.js", "webidl2.js", "widlparser"]

--- a/factory.py
+++ b/factory.py
@@ -14,7 +14,8 @@ def write_file(file, contents):
     dirs = os.path.dirname(file)
     if dirs:
         os.makedirs(dirs, exist_ok=True)
-    open(file, "w", encoding="utf-8").write(contents)
+    # `newline="\n"` forces Unix line endings on Windows
+    open(file, "w", encoding="utf-8", newline="\n").write(contents)
 
 def href_to_shortname(href):
     return href[len("https://"):href.index(".")]
@@ -51,6 +52,8 @@ def fill_template(contents, variables):
             continue
         elif variable == "extra_files" and data != "":
             data = "\n\tEXTRA_FILES=\"{}\" \\".format(data)
+        elif variable == "bikeshed_indent_size":
+            data = "{}".format(data)
         elif variable == "build_with_node":
             output = ""
             if data:
@@ -83,6 +86,7 @@ def update_files(shortname, name):
         "shortname": shortname,
         "h1": name,
         "extra_files": "",
+        "bikeshed_indent_size": 1,
         "build_with_node": "",
         "post_build_step": "",
         ".gitignore": [],

--- a/factory.py
+++ b/factory.py
@@ -14,8 +14,7 @@ def write_file(file, contents):
     dirs = os.path.dirname(file)
     if dirs:
         os.makedirs(dirs, exist_ok=True)
-    # `newline="\n"` forces Unix line endings on Windows
-    open(file, "w", encoding="utf-8", newline="\n").write(contents)
+    open(file, "w", encoding="utf-8").write(contents)
 
 def href_to_shortname(href):
     return href[len("https://"):href.index(".")]
@@ -53,7 +52,7 @@ def fill_template(contents, variables):
         elif variable == "extra_files" and data != "":
             data = "\n\tEXTRA_FILES=\"{}\" \\".format(data)
         elif variable == "bikeshed_indent_size":
-            data = "{}".format(data)
+            data = str(data)
         elif variable == "build_with_node":
             output = ""
             if data:


### PR DESCRIPTION
**WebIDL** uses 4 spaces for indentation in **Bikeshed** source files.

---

See <https://github.com/whatwg/webidl/pull/1040#issuecomment-939737611> by @annevk