### PR TITLE
Update various versions used in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml.template
+++ b/.github/workflows/build.yml.template
@@ -11,13 +11,13 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
     # Note: `python` will also be this version, which various scripts depend on.
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
-        python-version: 3.8@@build_with_node@@
+        python-version: 3.10@@build_with_node@@
     # Note: `make deploy` will do a deploy dry run on PRs.
     - run: make deploy
       env:

--- a/factory.py
+++ b/factory.py
@@ -55,9 +55,9 @@ def fill_template(contents, variables):
             output = ""
             if data:
                 output = """
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
     - run: npm install"""
             data = output
         elif variable == "post_build_step" and data != "":


### PR DESCRIPTION
* Updates the actions themselves from v2 to v3.
* Updates the Node version from v14 to v16 (latest LTS).
* Updates the Python version from v3.8 to v3.10 (latest stable).
---

IMO we should merge this but not update all the specs. We can just let this ride along with any other future updates.

That's a bit risky because maybe there is some incompatibility between Python v3.8 and Python v3.10 that we would discover by doing this sooner. And then when we're trying to roll out some other more-important change, we get caught up figuring that out. But, in my estimation based on how we use Python and Node, that's unlikely.