### PR TITLE
Quote Python version in .yml

### DIFF
--- a/.github/workflows/build.yml.template
+++ b/.github/workflows/build.yml.template
@@ -17,7 +17,7 @@ jobs:
     # Note: `python` will also be this version, which various scripts depend on.
     - uses: actions/setup-python@v3
       with:
-        python-version: 3.10@@build_with_node@@
+        python-version: "3.10"@@build_with_node@@
     # Note: `make deploy` will do a deploy dry run on PRs.
     - run: make deploy
       env:


### PR DESCRIPTION
This ensures it is interpreted correctly and not as 3.1. See https://github.com/whatwg/webidl/pull/1156 for context.