### PR TITLE
Install Bikeshed on CI

### DIFF
--- a/.github/workflows/build.yml.template
+++ b/.github/workflows/build.yml.template
@@ -15,9 +15,10 @@ jobs:
       with:
         fetch-depth: 2
     # Note: `python` will also be this version, which various scripts depend on.
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.10"@@build_with_node@@
+    - run: pip install bikeshed && bikeshed update
     # Note: `make deploy` will do a deploy dry run on PRs.
     - run: make deploy
       env:


### PR DESCRIPTION
This helps us move away from depending on the CSSWG API server, which is often broken.