### PR TITLE
Update Ubuntu, Python, and Node versions

### DIFF
--- a/.github/workflows/build.yml.template
+++ b/.github/workflows/build.yml.template
@@ -9,15 +9,14 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
-    # Note: `python` will also be this version, which various scripts depend on.
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"@@build_with_node@@
+        python-version: "3.11"@@build_with_node@@
     # Note: `make deploy` will do a deploy dry run on PRs.
     - run: make deploy
       env:

--- a/factory.py
+++ b/factory.py
@@ -57,7 +57,7 @@ def fill_template(contents, variables):
                 output = """
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm install"""
             data = output
         elif variable == "post_build_step" and data != "":


### PR DESCRIPTION
We could also do `ubuntu-latest` instead of choosing a specific Ubuntu version. I think that might be relatively safe?

I haven't tested the impact of Node v16 -> v18 or Python v3.10 -> v3.11 on our scripts, but I think it'll be fine.