### PR TITLE
Add more PULL_REQUEST_TEMPLATE instructions

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md.template
+++ b/PULL_REQUEST_TEMPLATE.md.template
@@ -14,6 +14,6 @@ If you think your PR is ready to land, please double-check that the checklist is
    * Gecko: …
    * WebKit: …@@extra_implementers@@
 - [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
-- [ ] There is a clear commit message to use when squashing this PR. Either squash the commits yourself or write the commit message here:
+- [ ] There is a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- Either squash the commits yourself or write the commit message here. -->
 
 (See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

--- a/PULL_REQUEST_TEMPLATE.md.template
+++ b/PULL_REQUEST_TEMPLATE.md.template
@@ -1,16 +1,19 @@
 <!--
 Thank you for contributing to the @@h1@@ Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
+If you think your PR is ready to land, please double-check that the checklist is complete before pinging.
 -->
 
+- [ ] The build is passing. <!-- You won't be able to check this until after you've sent the PR, to give Github time to run the build. -->
 - [ ] At least two implementers are interested (and none opposed):
    * …
    * …
 - [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
-   * …
+   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
 - [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
    * Chromium: …
    * Gecko: …
    * WebKit: …@@extra_implementers@@
 - [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
+- [ ] There is a clear commit message to use when squashing this PR. Either squash the commits yourself or write the commit message here:
 
 (See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

--- a/PULL_REQUEST_TEMPLATE.md.template
+++ b/PULL_REQUEST_TEMPLATE.md.template
@@ -1,9 +1,9 @@
 <!--
 Thank you for contributing to the @@h1@@ Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-If you think your PR is ready to land, please double-check that the checklist is complete before pinging.
+When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
+If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
 -->
 
-- [ ] The build is passing. <!-- You won't be able to check this until after you've sent the PR, to give Github time to run the build. -->
 - [ ] At least two implementers are interested (and none opposed):
    * …
    * …
@@ -14,6 +14,6 @@ If you think your PR is ready to land, please double-check that the checklist is
    * Gecko: …
    * WebKit: …@@extra_implementers@@
 - [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
-- [ ] There is a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- Either squash the commits yourself or write the commit message here. -->
+- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->
 
 (See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


### PR DESCRIPTION
To help people finish everything before pinging a PR for its final review.

This is based on some things Anne mentioned at https://matrix.to/#/!AGetWbsMpFPdSgUrbs:matrix.org/$eRoNst7XvM_u7lC03XyD44vEd8AwR029JvvrA7BDxXQ?via=matrix.org&via=mozilla.org&via=igalia.com. I'm not tied to any particular expression of these ideas and would be fine with being told that this isn't the right place to give these instructions.