### PR TITLE
Fix logic error in factory.py and exclude README.md from Web IDL for now

### DIFF
--- a/factory.json
+++ b/factory.json
@@ -58,6 +58,7 @@
     "bikeshed_indent_size": 4,
     "build_with_node": true,
     "post_build_step": "node ./check-grammar.js \"$$DIR/index.html\" && npm run webidl-grammar-post-processor -- --input \"$$DIR/index.html\"",
+    "not_these_templates": ["README.md"],
     "extra_implementers": ["Deno", "Node.js", "webidl2.js", "widlparser"]
   },
   "websockets": {

--- a/factory.py
+++ b/factory.py
@@ -39,16 +39,17 @@ def gather_files(extension):
     return files
 
 
-def fill_templates(templates, variables):
+def copy_and_fill_templates(variables):
     output = {}
-    for template in templates:
+    for template in TEMPLATES:
         output_name = template[:-len(".template")]
+        output_contents = TEMPLATES[template]
         if output_name == "README.md":
             if variables["readme"]:
-                templates[template] += "\n" + TEMPLATE_PARTS[variables["readme"]]
+                output_contents += "\n" + TEMPLATE_PARTS[variables["readme"]]
             if os.path.isfile("READMEEND.md"):
-                templates[template] += "\n" + read_file("READMEEND.md")
-        output[output_name] = fill_template(templates[template], variables)
+                output_contents += "\n" + read_file("READMEEND.md")
+        output[output_name] = fill_template(output_contents, variables)
     return output
 
 def fill_template(contents, variables):
@@ -108,7 +109,7 @@ def update_files(shortname, name, in_main=False):
         variables["bs"] = bs
         variables["source"] = bs + ".bs"
 
-    files = fill_templates(TEMPLATES, variables)
+    files = copy_and_fill_templates(variables)
 
     if in_main:
         subprocess.run(["git", "checkout", "main"], capture_output=True)


### PR DESCRIPTION
Instead of only modifying the template contents for a single specification, we were modifying them globally, causing erroneous output. This previously went unnoticed as we did not attempt to modify the template contents.

Additionally, exclude README.md from Web IDL for now as it has some custom things in there that need more consideration.