### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml.template
+++ b/.github/workflows/build.yml.template
@@ -14,10 +14,10 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.11"@@build_with_node@@
     - run: pip install bikeshed && bikeshed update

--- a/factory.py
+++ b/factory.py
@@ -64,9 +64,9 @@ def fill_template(contents, variables):
             data = "\nmax_line_length = {}".format(data)
         elif variable == "build_with_node" and data != "":
             data = """
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
     - run: npm install"""
         elif variable == "post_build_step" and data != "":
             data = "\n\tPOST_BUILD_STEP='{}' \\".format(data)


### PR DESCRIPTION
This updates checkout, setup-python, and setup-node to their latest versions, which will remove some warnings on CI.

It also updates the Node.js version used from v18 to v20.

(It does not update Python from v3.11 to v3.12, since Bikeshed is only tested on v3.11 currently.)

---

I think these should all be pretty safe without needing to do any particular tests.