### PR TITLE
Fix Bikeshed API endpoint in Makefile template

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -2,13 +2,15 @@ SHELL=/bin/bash -o pipefail
 .PHONY: local remote deploy
 
 remote: @@bs@@.bs
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	@ (HTTP_STATUS=$$(curl https://www.w3.org/publications/spec-generator/ \
 	                       --output @@bs@@.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
 	                       -F die-on=warning \
 	                       -F md-Text-Macro="COMMIT-SHA LOCAL COPY" \
-	                       -F file=@@@bs@@.bs) && \
+	                       -F file=@@@bs@@.bs \
+	                       -F type=bikeshed-spec \
+	                       -F output=html) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
 		echo ""; cat @@bs@@.html; echo ""; \
 		rm -f @@bs@@.html; \


### PR DESCRIPTION
Following https://github.com/whatwg/cookiestore/pull/297

The api.csswg.org/bikeshed/ endpoint no longer works. Migrate to www.w3.org/publications/spec-generator/ with the required type=bikeshed-spec and output=html parameters.
